### PR TITLE
Renaming socket class API.

### DIFF
--- a/source/m2mconnectionsecuritypimpl.cpp
+++ b/source/m2mconnectionsecuritypimpl.cpp
@@ -306,12 +306,12 @@ int M2MConnectionSecurityPimpl::read(unsigned char* buffer, uint16_t len){
 
 int f_send( void *ctx, const unsigned char *buf, size_t len){
     M2MConnectionHandler* handler = ((M2MConnectionHandler *) ctx);
-    return handler->sendToSocket(buf, len);
+    return handler->send_to_socket(buf, len);
 }
 
 int f_recv(void *ctx, unsigned char *buf, size_t len){
     M2MConnectionHandler* handler = ((M2MConnectionHandler *) ctx);
-    return handler->receiveFromSocket(buf, len);
+    return handler->receive_from_socket(buf, len);
 }
 
 int f_recv_timeout(void *ctx, unsigned char *buf, size_t len, uint32_t /*some*/){

--- a/test/mbed-client-mbed-tls/unittest/stub/m2mconnectionhandler_stub.cpp
+++ b/test/mbed-client-mbed-tls/unittest/stub/m2mconnectionhandler_stub.cpp
@@ -73,10 +73,10 @@ void M2MConnectionHandler::stop_listening()
 {
 }
 
-int M2MConnectionHandler::sendToSocket(const unsigned char *, size_t ){
+int M2MConnectionHandler::send_to_socket(const unsigned char *, size_t ){
     return m2mconnectionhandler_stub::int_value;
 }
 
-int M2MConnectionHandler::receiveFromSocket(unsigned char *buf, size_t len){
+int M2MConnectionHandler::receive_from_socket(unsigned char *buf, size_t len){
     return m2mconnectionhandler_stub::int_value;
 }


### PR DESCRIPTION
 - sendToSocket to send_to_socket()
 - receiveFromSocket to receive_from_socket()