### PR TITLE
Make the makefile to compile code into libmbed-client-mbedtls.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,23 @@
 #
 # List of subdirectories to build
 TEST_FOLDER := ./test/
+
+LIB = libmbed-client-mbedtls.a
+
 # List of unit test directories for libraries
 UNITTESTS := $(sort $(dir $(wildcard $(TEST_FOLDER)*/unittest/*)))
 TESTDIRS := $(UNITTESTS:%=build-%)
 CLEANTESTDIRS := $(UNITTESTS:%=clean-%)
 COVERAGEFILE := ./lcov/coverage.info
+
+include sources.mk
+include include_dirs.mk
+
+override CFLAGS += $(addprefix -I,$(INCLUDE_DIRS))
+override CFLAGS += $(addprefix -D,$(FLAGS))
+ifeq ($(DEBUG),1)
+override CFLAGS += -DHAVE_DEBUG
+endif
 
 #
 # Define compiler toolchain

--- a/include_dirs.mk
+++ b/include_dirs.mk
@@ -1,0 +1,15 @@
+INCLUDE_DIRS := \
+	../ \
+	. \
+	../../nsdl-c \
+	../../libService/libService \
+	../../libService/exported-libs/mbed-client-libservice \
+	../../libService \
+	../../mbedtls/include \
+        ../lwm2m-client \
+        ../lwm2m-client/mbed-client \
+        ../lwm2m-client-linux/source \
+        ../lwm2m-client-mbedtls \
+        source \
+
+

--- a/sources.mk
+++ b/sources.mk
@@ -1,0 +1,7 @@
+SRCS += \
+	source/m2mconnectionsecurity.cpp \
+	source/m2mconnectionsecuritypimpl.cpp \
+
+
+
+


### PR DESCRIPTION
Make the makefile to produce a library out of the sources defined
in sources.mk. This makes it possible to use this code eg. from
nanosimulator.