### PR TITLE
Fix for IOTCLT-675

### DIFF
--- a/mbed-client-mbedtls/m2mplatformabstract.h
+++ b/mbed-client-mbedtls/m2mplatformabstract.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014-2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef M2M_PLATFORM_ABSTRACT_H__
+#define M2M_PLATFORM_ABSTRACT_H__
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief Get random number for the underlying platform.
+ * This API needs to be implemented by the application using
+ * mbed Client in order to provide randomly generated number
+ * based on underlying platform, which will be used internally
+ * by mbed Client for SSL handshake mechanism.
+ */
+extern uint32_t get_random_number(void);
+#ifdef __cplusplus
+}
+#endif
+#endif // M2M_PLATFORM_ABSTRACT_H__

--- a/source/m2mconnectionsecuritypimpl.cpp
+++ b/source/m2mconnectionsecuritypimpl.cpp
@@ -16,9 +16,11 @@
 
 #include "mbed-client/m2mconnectionhandler.h"
 #include "mbed-client-mbedtls/m2mconnectionsecuritypimpl.h"
+#include "mbed-client-mbedtls/m2mplatformabstract.h"
 #include "mbed-client/m2mtimer.h"
 #include "mbed-client/m2msecurity.h"
 #include "mbed-trace/mbed_trace.h"
+
 #include <string.h>
 
 #define TRACE_GROUP "mClt"
@@ -354,7 +356,7 @@ int f_recv_timeout(void *ctx, unsigned char *buf, size_t len, uint32_t /*some*/)
 int entropy_poll( void *, unsigned char *output, size_t len,
                            size_t *olen )
 {
-    srand(time(NULL));
+    srand(get_random_number());
     char *c = (char*)malloc(len);
     memset(c, 0, len);
     for(uint16_t i=0; i < len; i++){

--- a/test/mbed-client-mbed-tls/unittest/m2mconnectionsecuritypimpl_mbedtls/test_m2mconnectionsecuritypimpl_mbedtls.cpp
+++ b/test/mbed-client-mbed-tls/unittest/m2mconnectionsecuritypimpl_mbedtls/test_m2mconnectionsecuritypimpl_mbedtls.cpp
@@ -21,6 +21,12 @@
 #include "mbedtls_stub.h"
 #include "mbed-client/m2mconnectionhandler.h"
 #include "m2mtimer_stub.h"
+#include "mbed-client-mbedtls/m2mplatformabstract.h"
+
+uint32_t get_random_number(void)
+{
+    return time(NULL);
+}
 
 class TestObserver : public M2MConnectionObserver {
 


### PR DESCRIPTION
There is now an abstract api introduced in mbed-client-mbedtls module uint32_t get_random_number()
which has to be implemented by application to provide random number. This replaces the earlier
hardcoded way of generating random number through usage of time() API which will not provide RTC in most
of the embedded platform.
This is one of the first enhancement for enabling application to add more randomization for entropy function
More feature like having mechanism for application to provide their own entroy sources will be added subsequently.

This PR will result in more PRs for other modules of mbed-client and example applications using mbed-client.