### PR TITLE
Save heap by avoiding a temporary copy of the pub./priv. keys.

### DIFF
--- a/source/m2mconnectionsecuritypimpl.cpp
+++ b/source/m2mconnectionsecuritypimpl.cpp
@@ -147,9 +147,10 @@ int M2MConnectionSecurityPimpl::init(const M2MSecurity *security)
         M2MSecurity::SecurityModeType cert_mode =
                 (M2MSecurity::SecurityModeType)security->resource_value_int(M2MSecurity::SecurityMode);
 
-        uint8_t *srv_public_key = 0;
-        uint8_t *public_key = 0;
-        uint8_t *sec_key = 0;
+        // Note: these are relatively large buffers, no point to make copy of them here as mbedtls will make a copy of them.
+        const uint8_t *srv_public_key = NULL;
+        const uint8_t *public_key = NULL;
+        const uint8_t *sec_key = NULL;
 
         uint32_t srv_public_key_size = security->resource_value_buffer(M2MSecurity::ServerPublicKey, srv_public_key);
         uint32_t public_key_size = security->resource_value_buffer(M2MSecurity::PublicKey, public_key);
@@ -189,10 +190,6 @@ int M2MConnectionSecurityPimpl::init(const M2MSecurity *security)
         /* Enable following two lines to get traces from mbedtls */
         /*mbedtls_ssl_conf_dbg( &_conf, mbedtls_debug, stdout );
         mbedtls_debug_set_threshold(3);*/
-
-        free(srv_public_key);
-        free(public_key);
-        free(sec_key);
     }
 
     if( ret == 0 ){

--- a/test/mbed-client-mbed-tls/unittest/stub/m2msecurity_stub.cpp
+++ b/test/mbed-client-mbed-tls/unittest/stub/m2msecurity_stub.cpp
@@ -85,6 +85,15 @@ uint32_t M2MSecurity::resource_value_buffer(SecurityResource,
     return m2msecurity_stub::int_value;
 }
 
+uint32_t M2MSecurity::resource_value_buffer(SecurityResource,
+                               const uint8_t *&value) const
+{
+    if( m2msecurity_stub::has_value ){
+        value = (const uint8_t*)"dummy";
+        return 6;
+    }
+    return m2msecurity_stub::int_value;
+}
 
 uint32_t M2MSecurity::resource_value_int(SecurityResource) const
 {


### PR DESCRIPTION
The public and private keys are in order of ~0,7KB in size, so
we better try to avoid copying them unnecessarily. Use the new
overloaded version of resource_value_buffer() and pass just the
reference of these buffers to mbedtls, as it will copy them.