### PR TITLE
Fixes Client mbed TLS abstraction for development head of mbed TLS

### DIFF
--- a/mbed-client-mbedtls/m2mconnectionsecuritypimpl.h
+++ b/mbed-client-mbedtls/m2mconnectionsecuritypimpl.h
@@ -23,6 +23,7 @@
 #include "mbed-client/m2msecurity.h"
 
 #include "mbedtls/config.h"
+#include "mbedtls/platform.h"
 #include "mbedtls/debug.h"
 #include "mbedtls/ssl.h"
 #include "mbedtls/entropy.h"


### PR DESCRIPTION
This change allows the mbed TLS type mbedtls_timer_t to be defined, required
for the upstream version of mbed TLS (> version 2.2.1).

Without this change, coap-service shouldn't build with the development head of mbed TLS.