### PR TITLE
Handle all mbedtls handshake errors correctly

### DIFF
--- a/source/m2mconnectionsecuritypimpl.cpp
+++ b/source/m2mconnectionsecuritypimpl.cpp
@@ -300,25 +300,15 @@ int M2MConnectionSecurityPimpl::continue_connecting()
 {
     tr_debug("M2MConnectionSecurityPimpl::continue_connecting");
     int ret=-1;
-    while( ret != M2MConnectionHandler::CONNECTION_ERROR_WANTS_READ){
-        ret = mbedtls_ssl_handshake( &_ssl );
+    while( ret != M2MConnectionHandler::CONNECTION_ERROR_WANTS_READ ){
+        ret = mbedtls_ssl_handshake_step( &_ssl );
         if( MBEDTLS_ERR_SSL_WANT_READ == ret ){
             ret = M2MConnectionHandler::CONNECTION_ERROR_WANTS_READ;
         }
-        else if (ret == -1) {
-            return -1;
+        else if (ret != 0) {
+            break;
         }
 
-        if(MBEDTLS_ERR_SSL_TIMEOUT == ret ||
-           MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO == ret ||
-           MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE == ret ||
-           MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_REQUEST == ret ||
-           MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE == ret ||
-           MBEDTLS_ERR_SSL_BAD_HS_SERVER_HELLO_DONE == ret ||
-           MBEDTLS_ERR_SSL_BAD_HS_CHANGE_CIPHER_SPEC == ret ||
-           MBEDTLS_ERR_SSL_BAD_HS_FINISHED == ret) {
-            return MBEDTLS_ERR_SSL_TIMEOUT;
-        }
         if( _ssl.state == MBEDTLS_SSL_HANDSHAKE_OVER ){
             return 0;
         }

--- a/test/mbed-client-mbed-tls/unittest/m2mconnectionsecuritypimpl_mbedtls/test_m2mconnectionsecuritypimpl_mbedtls.cpp
+++ b/test/mbed-client-mbed-tls/unittest/m2mconnectionsecuritypimpl_mbedtls/test_m2mconnectionsecuritypimpl_mbedtls.cpp
@@ -321,9 +321,13 @@ void Test_M2MConnectionSecurityPimpl::test_continue_connecting()
 
     mbedtls_stub::expected_int = MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_REQUEST;
     impl._ssl.state = MBEDTLS_SSL_CLIENT_HELLO;
-    CHECK( MBEDTLS_ERR_SSL_TIMEOUT == impl.continue_connecting());
+    CHECK( MBEDTLS_ERR_SSL_BAD_HS_CERTIFICATE_REQUEST == impl.continue_connecting());
 
     mbedtls_stub::expected_int = -6;
+    impl._ssl.state = MBEDTLS_SSL_HANDSHAKE_OVER;
+    CHECK( -6 == impl.continue_connecting());
+
+    mbedtls_stub::expected_int = 0;
     impl._ssl.state = MBEDTLS_SSL_HANDSHAKE_OVER;
     CHECK( 0 == impl.continue_connecting());
 }


### PR DESCRIPTION
Fixes issue where certificate verification would fail but handshake would still continue normally.

@yogpan01 @anttiylitokola @AnttiKauppila 